### PR TITLE
feat: add Copilot MCP allowlist registry and repo metadata

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @MediaMarktSaturn/engineering-platform

--- a/allowlist-servers.json
+++ b/allowlist-servers.json
@@ -1,0 +1,26 @@
+{
+  "servers": [
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+        "name": "github",
+        "description": "Official GitHub MCP Server for Copilot",
+        "repository": {
+          "url": "https://github.com/modelcontextprotocol/servers.git",
+          "source": "github"
+        },
+        "version": "2025.4.8",
+        "packages": [
+          {
+            "registryType": "npm",
+            "identifier": "@modelcontextprotocol/server-github",
+            "version": "2025.4.8",
+            "transport": {
+              "type": "stdio"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: github-org-config
+  title: GitHub Organization Configuration (.github)
+  description: "Repository for GitHub organization-wide default files and Copilot MCP allowlist registry."
+  annotations:
+    github.com/project-slug: MediaMarktSaturn/.github
+    github.com/team-slug: MediaMarktSaturn/engineering-platform
+spec:
+  type: service
+  lifecycle: production
+  owner: Engineering Platform


### PR DESCRIPTION
This PR adds the allowlist-servers JSON needed to configure GitHub Copilot's MCP registry enforcement, specifically allowing the official GitHub MCP server. It also brings this repository up to standard by adding the `CODEOWNERS` and `catalog-info.yaml` files.